### PR TITLE
Adjust the deploymet job for ECR images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.python-version
 
 # C extensions
 *.so

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -75,7 +75,7 @@ def print_file_chunk(url, offset, auth):
 def get_marathon_json():
     """
     Return the json configuration for the Mesos app.
-    Assumes a Jenkins job is providing the following vars, some sensitive:
+    Assumes a Jenkins job is providing the following vars:
 
     VAR   | example
     :---- | :--------
@@ -95,7 +95,8 @@ def get_marathon_json():
     PG_USERNAME           | (sensitive)
     PG_PASSWORD           | (sensitive)
     HOST_BULK             | (sensitive)
-    
+    AWS_ACCESS_KEY_ID     | (for ECR)
+    AWS_SECRET_ACCESS_KEY | (for ECR)
     """
     ATTACHMENTS_ROOT = os.getenv("ATTACHMENTS_ROOT")
 
@@ -147,7 +148,7 @@ def get_marathon_json():
             "PGPASSWORD": os.getenv("PG_PASSWORD"),
             "STATIC_URL": "/static/",
             "HOST_BULK": os.getenv("HOST_BULK"),
-            "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID"),  # ECR keys
+            "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID"),
             "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_SECRET_ACCESS_KEY"),
         },
         "healthChecks": [
@@ -198,7 +199,7 @@ if __name__ == '__main__':
     marathon_user = os.getenv("MARATHON_USER", None)
     marathon_password = os.getenv("MARATHON_PASSWORD", None)
     marathon_force = True if os.getenv(
-        "MARATHON_FORCE_DEPLOY", "false") == "true" else False
+        "MARATHON_FORCE_DEPLOY") == "true" else False
     marathon_framework_name = os.getenv("MARATHON_FRAMEWORK_NAME", "marathon")
     marathon_retries = int(os.getenv("MARATHON_RETRIES", 3))
     if os.getenv("MARATHON_JENKINS"):

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,7 +145,7 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
-        "uris": [],
+        "uris": ["https://www.consumerfinance.gov//static/favicon.ccb3dcabd67e.ico"],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
             "ES_SERVER_ENV": "staging",

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,7 +145,6 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
-        "fetcher_cache_size": 0,
         "fetch": [
             {
                 "uri": None

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -183,7 +183,7 @@ def get_marathon_json():
                 "gracePeriodSeconds": 1200,
                 "intervalSeconds": 120,
                 "timeoutSeconds": 120,
-                "maxConsecutiveFailures": 3,
+                "maxConsecutiveFailures": 6,
                 "ignoreHttp1xx": False
             }
         ]

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -82,24 +82,33 @@ def get_marathon_json():
 
     Assumes a Jenkins job is providing the following vars:
 
-    VAR                 | example
-    :----               | :--------
-    MARATHON_VARS_ONLY  | true (Jenkins is delivering vars, not json)
-    MARATHON_APP_ID     | "/complaint-search/search-tool-staging" 
-    MLT_ROOT            | "/home/dtwork/applications/similarity"
-    ATTACHMENTS_ROOT    | "/home/dtwork/"
-    DOCKER_USER         | (sensitive)
-    MESOS_MASTER_URLS   | (sensitive)
-    MESOS_AGENT_MAP     | (sensitive)
-    ES_USERNAME         | (sensitive)
-    ES_PASSWORD         | (sensitive)
-    LDAP_HOST           | (sensitive)
-    LDAP_USERNAME       | (sensitive)
-    LDAP_PASSWORD       | (sensitive)
-    LDAP_BASE_DN        | (sensitive)
-    PG_USERNAME         | (sensitive)
-    PG_PASSWORD         | (sensitive)
-    HOST_BULK           | (sensitive)
+    VAR                    | example
+    :----                  | :--------
+    MARATHON_VARS_ONLY     | true (Jenkins is delivering vars, not json)
+    MARATHON_APP_ID        | "/complaint-search/search-tool-staging" 
+    MLT_ROOT               | "/home/dtwork/applications/similarity"
+    ATTACHMENTS_ROOT       | "/home/dtwork/"
+    DOCKER_USER            | (sensitive)
+    MESOS_MASTER_URLS      | (sensitive)
+    MESOS_AGENT_MAP        | (sensitive)
+    ES_USERNAME            | (sensitive)
+    ES_PASSWORD            | (sensitive)
+    LDAP_HOST              | (sensitive)
+    LDAP_USERNAME          | (sensitive)
+    LDAP_PASSWORD          | (sensitive)
+    LDAP_BASE_DN           | (sensitive)
+    PG_USERNAME            | (sensitive)
+    PG_PASSWORD            | (sensitive)
+    HOST_BULK              | (sensitive)
+    ES_SERVER_ENV          | staging
+    DJANGO_SETTINGS_MODULE | search_tool.mesos
+    ES_HOST                | (sensitive)
+    ES_INDEX_ATTACHMENT    | complaint-crdb-attachment-staging
+    ES_INDEX_COMPLAINT     | complaint-crdb-staging
+
+
+
+
     """
     ATTACHMENTS_ROOT = os.getenv("ATTACHMENTS_ROOT")
     MLT_ROOT = os.getenv(
@@ -146,11 +155,11 @@ def get_marathon_json():
         "uris": [],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
-            "ES_SERVER_ENV": "staging",
-            "DJANGO_SETTINGS_MODULE": "search_tool.mesos",
-            "ES_HOST": "https://es2.data.cfpb.local/",
-            "ES_INDEX_ATTACHMENT": "complaint-crdb-attachment-staging",
-            "ES_INDEX_COMPLAINT": "complaint-crdb-staging",
+            "ES_SERVER_ENV": os.getenv("ES_SERVER_ENV"),
+            "DJANGO_SETTINGS_MODULE": os.getenv("DJANGO_SETTINGS_MODULE"),
+            "ES_HOST": os.getenv("ES_HOST"),
+            "ES_INDEX_ATTACHMENT": os.getenv("ES_INDEX_ATTACHMENT"),
+            "ES_INDEX_COMPLAINT": os.getenv("ES_INDEX_COMPLAINT"),
             "ES_USERNAME": os.getenv("ES_USERNAME"),
             "ES_PASSWORD": os.getenv("ES_PASSWORD"),
             "LDAP_HOST": os.getenv("LDAP_HOST"),
@@ -159,7 +168,6 @@ def get_marathon_json():
             "LDAP_BASE_DN": os.getenv("LDAP_BASE_DN"),
             "PGUSER": os.getenv("PG_USERNAME"),
             "PGPASSWORD": os.getenv("PG_PASSWORD"),
-            "STATIC_URL": "/static/",
             "HOST_BULK": os.getenv("HOST_BULK"),
         },
         "healthChecks": [

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -4,7 +4,7 @@ import json
 import time
 import logging
 import pprint
-from io import BytesIO
+from io import StringIO
 
 import requests
 
@@ -117,7 +117,7 @@ def get_marathon_json():
             }
         }
     }
-    docker_auth_file = BytesIO(json.dumps(docker_auth))
+    docker_auth_file = StringIO(json.dumps(docker_auth))
 
     app_config = {
         "id": MARATHON_APP_ID,

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -147,6 +147,8 @@ def get_marathon_json():
             "PGPASSWORD": os.getenv("PG_PASSWORD"),
             "STATIC_URL": "/static/",
             "HOST_BULK": os.getenv("HOST_BULK"),
+            "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID"),  # ECR keys
+            "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_SECRET_ACCESS_KEY"),
         },
         "healthChecks": [
             {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -4,7 +4,6 @@ import json
 import time
 import logging
 import pprint
-from io import StringIO
 
 import requests
 
@@ -101,7 +100,7 @@ def get_marathon_json():
     PG_USERNAME           | (sensitive)
     PG_PASSWORD           | (sensitive)
     HOST_BULK             | (sensitive)
-    ECRPW                 | (sensitive)
+    DOCKER_CONFIG_FILE    | (sensitive)
     """
     ATTACHMENTS_ROOT = os.getenv("ATTACHMENTS_ROOT")
     MLT_ROOT = os.getenv(
@@ -109,21 +108,20 @@ def get_marathon_json():
         f"{ATTACHMENTS_ROOT}/applications/similarity"
     )
 
-    docker_auth = {
-        "auths": {
-            "https://795649122172.dkr.ecr.us-east-1.amazonaws.com": {
-                "username": "AWS",
-                "password": os.getenv("ECRPW")
-            }
-        }
-    }
-    docker_auth_file = StringIO(json.dumps(docker_auth))
+    # docker_auth = {
+    #     "auths": {
+    #         "https://795649122172.dkr.ecr.us-east-1.amazonaws.com": {
+    #             "username": "AWS",
+    #             "password": os.getenv("ECRPW")
+    #         }
+    #     }
+    # }
 
     app_config = {
         "id": MARATHON_APP_ID,
         "secrets": {
             "pullConfigSecret": {
-                "source": docker_auth_file
+                "source": os.getenv("DOCKER_CONFIG_FILE")
             }
         },
         "container": {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,7 +145,6 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
-        "fetch": [],
         "uris": [],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -17,9 +17,13 @@ STDERR_URL = "{}/files/read.json?path=/opt/mesos/slaves/{}/frameworks/{}/executo
 OFFSET = "&offset={}&length={}"
 MARATHON_APP_ID = os.getenv("MARATHON_APP_ID", "test-app")
 
-# Setup Logging
 logger = logging.getLogger('marathon-cli')
 logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+logger.addHandler(ch)
+
+pp = pprint.PrettyPrinter(indent=2, width=120, depth=4)
 
 
 def get_task_by_version(client, app_id, version):
@@ -234,7 +238,6 @@ if __name__ == '__main__':
                 }
             ]
         }"""
-    pp = pprint.PrettyPrinter(indent=2, width=120, depth=4)
     print("marathon json config:")
     pp.pprint(json.loads(marathon_app))
 

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -20,7 +20,7 @@ MARATHON_APP_ID = os.getenv("MARATHON_APP_ID", "test-app")
 logger = logging.getLogger('marathon-cli')
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
+ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
 pp = pprint.PrettyPrinter(indent=2, width=120, depth=4)

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -105,7 +105,7 @@ def get_marathon_json():
         "container": {
             "docker": {
                 "image": os.getenv("FQDI"),
-                "forcePullImage": True
+                "forcePullImage": False
             },
             "volumes": [
                 {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -123,7 +123,7 @@ def get_marathon_json():
             "pullConfigSecret": {
                 "source": docker_auth
             }
-        }
+        },
         "container": {
             "docker": {
                 "image": os.getenv("FQDI"),

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -119,17 +119,10 @@ def get_marathon_json():
 
     app_config = {
         "id": MARATHON_APP_ID,
-        "secrets": {
-            "pullConfigSecret": {
-                "source": os.getenv("DOCKER_CONFIG_FILE")
-            }
-        },
         "container": {
             "docker": {
                 "image": os.getenv("FQDI"),
-                "pullConfig": {
-                    "secret": "pullConfigSecret"
-                } 
+                "forcePullImage": False
             },
             "volumes": [
                 {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,6 +145,12 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
+        "fetcher_cache_size": 0,
+        "fetch": [
+            {
+                "uri": None
+            }
+        ],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
             "ES_SERVER_ENV": "staging",

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,9 +145,7 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
-        "uris": [
-            "https://www.consumerfinance.gov//static/favicon.ccb3dcabd67e.ico"
-        ],
+        "uris": [],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
             "ES_SERVER_ENV": "staging",

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -108,15 +108,28 @@ def get_marathon_json():
         f"{ATTACHMENTS_ROOT}/applications/similarity"
     )
 
+    docker_auth = {
+        "auths": {
+            "https://795649122172.dkr.ecr.us-east-1.amazonaws.com": {
+                "username": "AWS",
+                "password": os.getenv("ECRPW")
+            }
+        }
+    }
+
     app_config = {
         "id": MARATHON_APP_ID,
+        "secrets": {
+            "pullConfigSecret": {
+                "source": docker_auth
+            }
+        }
         "container": {
             "docker": {
                 "image": os.getenv("FQDI"),
-                "credential": {
-                    "username": "AWS",
-                    "password": os.getenv('ECRPW')
-                }
+                "pullConfig": {
+                    "secret": "pullConfigSecret"
+                } 
             },
             "volumes": [
                 {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -100,7 +100,7 @@ def get_marathon_json():
     """
     ATTACHMENTS_ROOT = os.getenv("ATTACHMENTS_ROOT")
 
-    app_data = {
+    app_config = {
         "id": MARATHON_APP_ID,
         "container": {
             "docker": {
@@ -164,7 +164,7 @@ def get_marathon_json():
             }
         ]
     }
-    return json.dumps(app_data, indent=2)
+    return json.dumps(app_config, indent=2)
 
 
 if __name__ == '__main__':
@@ -270,7 +270,7 @@ if __name__ == '__main__':
         version = response.version
         depolyment_id = response.deployments[0].id
     else:
-        client.list_apps()
+        logger.info(f"Apps list: {client.list_apps()}")
         response = client.update_app(
             marathon_app_id,
             app_definition,

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -113,7 +113,7 @@ def get_marathon_json():
         "container": {
             "docker": {
                 "image": os.getenv("FQDI"),
-                "pullConfig": {
+                "credential": {
                     "username": "AWS",
                     "password": os.getenv('ECRPW')
                 }

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,7 +145,9 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
-        "uris": [],
+        "uris": [
+            "https://www.consumerfinance.gov//static/favicon.ccb3dcabd67e.ico"
+        ],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
             "ES_SERVER_ENV": "staging",
@@ -211,7 +213,7 @@ if __name__ == '__main__':
         "MARATHON_URLS", "http://localhost:8080").split(',')
     marathon_user = os.getenv("MARATHON_USER", None)
     marathon_password = os.getenv("MARATHON_PASSWORD", None)
-    marathon_force = True  # if os.getenv("MARATHON_FORCE_DEPLOY") == "true" else False
+    marathon_force = True
     marathon_framework_name = os.getenv("MARATHON_FRAMEWORK_NAME", "marathon")
     marathon_retries = int(os.getenv("MARATHON_RETRIES", 3))
     if os.getenv("APP_STOP"):
@@ -231,7 +233,7 @@ if __name__ == '__main__':
         marathon_app = os.getenv("MARATHON_APP")
     else:
         # we fall back to default app json config
-        marathon_app = """
+        marathon_app = """  # noqa
         {
             "id": "/test-app",
             "cmd": "mv *.war apache-tomcat-*/webapps && cd apache-tomcat-* && sed \\"s/8080/$PORT/g\\" < ./conf/server.xml > ./conf/server-mesos.xml && sleep 15 && ./bin/catalina.sh run -config ./conf/server-mesos.xml",

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -147,7 +147,7 @@ def get_marathon_json():
         "instances": 2,
         "fetch": [
             {
-                "uri": None
+                "uri": ""
             }
         ],
         "user": f'{os.getenv("DOCKER_USER")}',

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -271,6 +271,7 @@ if __name__ == '__main__':
         version = response.version
         depolyment_id = response.deployments[0].id
     else:
+        client.list_apps()
         response = client.update_app(
             marathon_app_id,
             app_definition,

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -18,8 +18,8 @@ OFFSET = "&offset={}&length={}"
 MARATHON_APP_ID = os.getenv("MARATHON_APP_ID", "test-app")
 
 # Setup Logging
-logger = logging.getLogger('marathon')
-logger.setLevel(logging.INFO)
+logger = logging.getLogger('marathon-cli')
+logger.setLevel(logging.DEBUG)
 
 
 def get_task_by_version(client, app_id, version):

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -23,7 +23,7 @@ ch = logging.StreamHandler()
 ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
-pp = pprint.PrettyPrinter(indent=2, width=120, depth=4)
+pp = pprint.PrettyPrinter(indent=2, width=120, depth=6)
 
 
 def get_task_by_version(client, app_id, version):
@@ -121,7 +121,7 @@ def get_marathon_json():
         "id": MARATHON_APP_ID,
         "secrets": {
             "pullConfigSecret": {
-                "source": docker_auth
+                "source": json.loads(docker_auth)
             }
         },
         "container": {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -100,8 +100,7 @@ def get_marathon_json():
     PG_USERNAME           | (sensitive)
     PG_PASSWORD           | (sensitive)
     HOST_BULK             | (sensitive)
-    AWS_ACCESS_KEY_ID     | (for ECR)
-    AWS_SECRET_ACCESS_KEY | (for ECR)
+    ECRPW                 | (sensitive)
     """
     ATTACHMENTS_ROOT = os.getenv("ATTACHMENTS_ROOT")
     MLT_ROOT = os.getenv(
@@ -114,7 +113,10 @@ def get_marathon_json():
         "container": {
             "docker": {
                 "image": os.getenv("FQDI"),
-                "forcePullImage": False
+                "pullConfig": {
+                    "username": "AWS",
+                    "password": os.getenv('ECRPW')
+                }
             },
             "volumes": [
                 {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -214,7 +214,16 @@ if __name__ == '__main__':
     marathon_force = True  # if os.getenv("MARATHON_FORCE_DEPLOY") == "true" else False
     marathon_framework_name = os.getenv("MARATHON_FRAMEWORK_NAME", "marathon")
     marathon_retries = int(os.getenv("MARATHON_RETRIES", 3))
-    if os.getenv("MARATHON_VARS_ONLY"):
+    if os.getenv("APP_STOP"):
+        # A simple request to stop the containers to prep for a deployment
+        marathon_app = """
+        {
+          "id": "f'{MARATHON_APP_ID}'",
+          "instances": 0,
+          "user": "root"
+        }
+        """
+    elif os.getenv("MARATHON_VARS_ONLY"):
         # Jenkins is providing env vars only, not a full json structure
         marathon_app = get_marathon_json()
     elif os.getenv("MARATHON_APP"):

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -177,9 +177,12 @@ def get_marathon_json():
                 "path": "/",
                 "protocol": "HTTP",
                 "portIndex": 0,
-                "gracePeriodSeconds": 600,
-                "intervalSeconds": 60,
-                "timeoutSeconds": 60,
+                # "gracePeriodSeconds": 600,
+                # "intervalSeconds": 60,
+                # "timeoutSeconds": 60,
+                "gracePeriodSeconds": 1200,
+                "intervalSeconds": 120,
+                "timeoutSeconds": 120,
                 "maxConsecutiveFailures": 3,
                 "ignoreHttp1xx": False
             }

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,6 +145,8 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
+        "fetch": [],
+        "uris": [],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
             "ES_SERVER_ENV": "staging",

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -209,7 +209,7 @@ if __name__ == '__main__':
     mesos_agent_map_string = os.getenv("MESOS_AGENT_MAP", None)
     mesos_master_urls = os.getenv("MESOS_MASTER_URLS", "http://localhost:5050").split(',')
 
-    pp = pprint.PrettyPrinter(depth=2)
+    pp = pprint.PrettyPrinter(depth=2, width=120)
 
     exit_code = 0
     auth = None
@@ -220,7 +220,8 @@ if __name__ == '__main__':
     logging.basicConfig(format="%(levelname)-8s %(message)s", level=getattr(logging, log_level.upper()))
     logging.getLogger('marathon').setLevel(logging.WARN) # INFO is too chatty
 
-    logging.info("Parsing JSON app definition...")
+    logging.warn("Parsing this JSON app definition")
+    logging.warn(pp.pprint(marathon_app))
     app_definition = MarathonApp.from_json(json.loads(marathon_app))
 
     try:

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -198,8 +198,7 @@ if __name__ == '__main__':
         "MARATHON_URLS", "http://localhost:8080").split(',')
     marathon_user = os.getenv("MARATHON_USER", None)
     marathon_password = os.getenv("MARATHON_PASSWORD", None)
-    marathon_force = True if os.getenv(
-        "MARATHON_FORCE_DEPLOY") == "true" else False
+    marathon_force = True  # if os.getenv("MARATHON_FORCE_DEPLOY") == "true" else False
     marathon_framework_name = os.getenv("MARATHON_FRAMEWORK_NAME", "marathon")
     marathon_retries = int(os.getenv("MARATHON_RETRIES", 3))
     if os.getenv("MARATHON_VARS_ONLY"):

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -121,7 +121,7 @@ def get_marathon_json():
         "id": MARATHON_APP_ID,
         "secrets": {
             "pullConfigSecret": {
-                "source": json.loads(docker_auth)
+                "source": json.dumps(docker_auth)
             }
         },
         "container": {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -202,9 +202,12 @@ if __name__ == '__main__':
         "MARATHON_FORCE_DEPLOY") == "true" else False
     marathon_framework_name = os.getenv("MARATHON_FRAMEWORK_NAME", "marathon")
     marathon_retries = int(os.getenv("MARATHON_RETRIES", 3))
-    if os.getenv("MARATHON_JENKINS"):
-        # Jenkins is supplying env vars
+    if os.getenv("MARATHON_VARS_ONLY"):
+        # Jenkins is providing env vars only, not a full json structure
         marathon_app = get_marathon_json()
+    elif os.getenv("MARATHON_APP"):
+        # Jenkins is providing a full json structure via env var
+        marathon_app = os.getenv("MARATHON_APP")
     else:
         # we fall back to default app json config
         marathon_app = """

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -4,6 +4,7 @@ import json
 import time
 import logging
 import pprint
+from io import BytesIO
 
 import requests
 
@@ -116,12 +117,13 @@ def get_marathon_json():
             }
         }
     }
+    docker_auth_file = BytesIO(json.dumps(docker_auth))
 
     app_config = {
         "id": MARATHON_APP_ID,
         "secrets": {
             "pullConfigSecret": {
-                "source": json.dumps(docker_auth)
+                "source": docker_auth_file
             }
         },
         "container": {

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -83,7 +83,7 @@ def get_marathon_json():
 
     VAR   | example
     :---- | :--------
-    MARATHON_JENKINS      | true (flag that Jenkins is delivering these vars)
+    MARATHON_VARS_ONLY    | true (Jenkins is delivering vars, not json)
     MARATHON_FORCE_DEPLOY | true
     MARATHON_APP_ID       | "/complaint-search/search-tool-staging" 
     ATTACHMENTS_ROOT      | "/home/dtwork/"
@@ -273,7 +273,7 @@ if __name__ == '__main__':
         version = response.version
         depolyment_id = response.deployments[0].id
     else:
-        logger.info(f"Apps list: {client.list_apps()}")
+        # logger.info(f"Apps list: {pp.pprint(client.list_apps())}")
         response = client.update_app(
             marathon_app_id,
             app_definition,

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -105,11 +105,8 @@ def get_marathon_json():
     ES_HOST                | (sensitive)
     ES_INDEX_ATTACHMENT    | complaint-crdb-attachment-staging
     ES_INDEX_COMPLAINT     | complaint-crdb-staging
-
-
-
-
     """
+
     ATTACHMENTS_ROOT = os.getenv("ATTACHMENTS_ROOT")
     MLT_ROOT = os.getenv(
         "MLT_ROOT",
@@ -155,9 +152,11 @@ def get_marathon_json():
         "uris": [],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
-            "ES_SERVER_ENV": os.getenv("ES_SERVER_ENV"),
-            "DJANGO_SETTINGS_MODULE": os.getenv("DJANGO_SETTINGS_MODULE"),
-            "ES_HOST": os.getenv("ES_HOST"),
+            "ES_SERVER_ENV": os.getenv("ES_SERVER_ENV", "staging"),
+            "DJANGO_SETTINGS_MODULE": os.getenv(
+                "DJANGO_SETTINGS_MODULE", "search_tool.mesos"
+            ),
+            "ES_HOST": os.getenv("ES_HOST", ""),
             "ES_INDEX_ATTACHMENT": os.getenv("ES_INDEX_ATTACHMENT"),
             "ES_INDEX_COMPLAINT": os.getenv("ES_INDEX_COMPLAINT"),
             "ES_USERNAME": os.getenv("ES_USERNAME"),

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -145,11 +145,6 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
-        "fetch": [
-            {
-                "uri": ""
-            }
-        ],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
             "ES_SERVER_ENV": "staging",

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -18,7 +18,7 @@ OFFSET = "&offset={}&length={}"
 MARATHON_APP_ID = os.getenv("MARATHON_APP_ID", "test-app")
 
 logger = logging.getLogger('marathon-cli')
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 ch = logging.StreamHandler()
 ch.setLevel(logging.INFO)
 logger.addHandler(ch)
@@ -145,7 +145,7 @@ def get_marathon_json():
         "mem": 8000,
         "disk": 5000,
         "instances": 2,
-        "uris": ["https://www.consumerfinance.gov//static/favicon.ccb3dcabd67e.ico"],
+        "uris": [],
         "user": f'{os.getenv("DOCKER_USER")}',
         "env": {
             "ES_SERVER_ENV": "staging",
@@ -163,8 +163,6 @@ def get_marathon_json():
             "PGPASSWORD": os.getenv("PG_PASSWORD"),
             "STATIC_URL": "/static/",
             "HOST_BULK": os.getenv("HOST_BULK"),
-            "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID"),
-            "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_SECRET_ACCESS_KEY"),
         },
         "healthChecks": [
             {
@@ -284,7 +282,6 @@ if __name__ == '__main__':
         version = response.version
         depolyment_id = response.deployments[0].id
     else:
-        # logger.info(f"Apps list: {pp.pprint(client.list_apps())}")
         response = client.update_app(
             marathon_app_id,
             app_definition,

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -86,6 +86,7 @@ def get_marathon_json():
     MARATHON_VARS_ONLY    | true (Jenkins is delivering vars, not json)
     MARATHON_FORCE_DEPLOY | true
     MARATHON_APP_ID       | "/complaint-search/search-tool-staging" 
+    MLT_ROOT              | "/home/dtwork/applications/similarity"
     ATTACHMENTS_ROOT      | "/home/dtwork/"
     DOCKER_USER           | (sensitive)
     MESOS_MASTER_URLS     | (sensitive)
@@ -103,6 +104,10 @@ def get_marathon_json():
     AWS_SECRET_ACCESS_KEY | (for ECR)
     """
     ATTACHMENTS_ROOT = os.getenv("ATTACHMENTS_ROOT")
+    MLT_ROOT = os.getenv(
+        "MLT_ROOT",
+        f"{ATTACHMENTS_ROOT}/applications/similarity"
+    )
 
     app_config = {
         "id": MARATHON_APP_ID,
@@ -125,6 +130,11 @@ def get_marathon_json():
                 {
                     "containerPath": "/etc/pki/ca-trust",
                     "hostPath": "/etc/pki/ca-trust",
+                    "mode": "RO"
+                },
+                {
+                    "containerPath": MLT_ROOT,
+                    "hostPath": MLT_ROOT,
                     "mode": "RO"
                 }
             ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 #marathon==0.9.3
--e git+https://github.com/higs4281/marathon-python.git#egg=marathon
+-e git+https://github.com/cfpb/marathon-python.git#egg=marathon
 requests==2.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 #marathon==0.9.3
--e git+https://github.com/tanderegg/marathon-python.git@revive_offers_repetitions#egg=marathon
+-e git+https://github.com/higs4281/marathon-python.git#egg=marathon
 requests==2.12.3


### PR DESCRIPTION
As part of this refactor, required by a change in Docker registries,
we drop the json-as-env-var structure, which was brittle, and
build the json configuration in the python script.

Sensitive bits come from Jenkins env vars.

cc @dvbalen 