### PR TITLE
Update README with branch usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # marathon-cli
 Command line tool for deploying applications via Marathon
+
+## Branch usage
+As of Summer 2022
+- `master` – The default branch, used by about a dozen jobs
+- `main` – A branch used by a handful of Data Products jobs
+- `unicode_fix` – Used by at least one job 


### PR DESCRIPTION
This repo doesn't follow branch naming conventions used elsewhere in the cfpb org.
This adds a note to explain how the active branches are being used.