### PR TITLE
Fix staging attachment config

### DIFF
--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -125,7 +125,7 @@ def get_marathon_json():
             "mode": "RO"
         }
     ]
-    if ATTACHMENTS_ROOT:
+    if BALE_DIR:  # deploying the bulk app
         volumes += [
             {
                 "containerPath": f"{ATTACHMENTS_ROOT}/attachments/mosaic",
@@ -138,7 +138,20 @@ def get_marathon_json():
                 "mode": "RO"
             }
         ]
-    if MLT_ROOT:
+    else:
+        volumes += [
+            {
+                "containerPath": f"{ATTACHMENTS_ROOT}/mosaic",
+                "hostPath": "/home/dtwork/mosaic",
+                "mode": "RO"
+            },
+            {
+                "containerPath": f"{ATTACHMENTS_ROOT}/rightnow",
+                "hostPath": "/home/dtwork/rightnow",
+                "mode": "RO"
+            }
+        ]
+            if MLT_ROOT:
         volumes.append(
             {
                 "containerPath": MLT_ROOT,

--- a/marathon-cli.py
+++ b/marathon-cli.py
@@ -151,7 +151,7 @@ def get_marathon_json():
                 "mode": "RO"
             }
         ]
-            if MLT_ROOT:
+    if MLT_ROOT:
         volumes.append(
             {
                 "containerPath": MLT_ROOT,


### PR DESCRIPTION
A fix pushed for bulk deployments stepped on the attachments mount for the search app. 

The test for a bulk deploy should be the existence of a `BALE_DIR` var, not 
the existence of an `ATTACHMENTS_ROOT` var, which both bulk and the app use.

## Testing
This branch has been tested in pcloud prod Jenkins, via **complaint-explorer-deploy-staging-from-ecr** job #439, to deploy an update to staging. It appears to have fixed attachment paths there.